### PR TITLE
Abrandoned/cleanup warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ int redisClustervAppendCommand(redisClusterContext *cc, const char *format, va_l
 int redisClusterAppendCommand(redisClusterContext *cc, const char *format, ...);
 int redisClusterAppendCommandArgv(redisClusterContext *cc, int argc, const char **argv, const size_t *argvlen);
 int redisClusterGetReply(redisClusterContext *cc, void **reply);
-void redisCLusterReset(redisClusterContext *cc);
+void redisClusterReset(redisClusterContext *cc);
 
 redisClusterAsyncContext *redisClusterAsyncConnect(const char *addrs, int flags);
 int redisClusterAsyncSetConnectCallback(redisClusterAsyncContext *acc, redisConnectCallback *fn);
@@ -145,9 +145,9 @@ subsequent replies. The return value for this function is either `REDIS_OK` or `
 the latter means an error occurred while reading a reply. Just as with the other commands,
 the `err` field in the context can be used to find out what the cause of this error is.
 ```c
-void redisCLusterReset(redisClusterContext *cc);
+void redisClusterReset(redisClusterContext *cc);
 ```
-Warning: You must call `redisCLusterReset` function after one pipelining anyway.
+Warning: You must call `redisClusterReset` function after one pipelining anyway.
 
 The following examples shows a simple cluster pipeline:
 ```c
@@ -158,7 +158,7 @@ redisClusterGetReply(clusterContext,&reply); // reply for SET
 freeReplyObject(reply);
 redisClusterGetReply(clusterContext,&reply); // reply for GET
 freeReplyObject(reply);
-redisCLusterReset(clusterContext);
+redisClusterReset(clusterContext);
 ```
 This API can also be used to implement a blocking subscriber:
 ```c
@@ -168,7 +168,7 @@ while(redisClusterGetReply(clusterContext,&reply) == REDIS_OK) {
     // consume message
     freeReplyObject(reply);
 }
-redisCLusterReset(clusterContext);
+redisClusterReset(clusterContext);
 ```
 
 ## Cluster asynchronous API

--- a/command.h
+++ b/command.h
@@ -2,6 +2,7 @@
 #define __COMMAND_H_
 
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "hiredis.h"
 #include "adlist.h"

--- a/command.h
+++ b/command.h
@@ -163,7 +163,7 @@ struct cmd {
     unsigned             quit:1;          /* quit request? */
     unsigned             noforward:1;     /* not need forward (example: ping) */
 
-    int                  slot_num;        /* this command should send to witch slot? 
+    int                  slot_num;        /* this command should send to which slot? 
                                                                           * -1:the keys in this command cross different slots*/
     struct cmd           **frag_seq;      /* sequence of fragment command, map from keys to fragments*/
 

--- a/hircluster.c
+++ b/hircluster.c
@@ -2375,7 +2375,7 @@ static cluster_node *node_get_by_table(redisClusterContext *cc, uint32_t slot_nu
     
 }
 
-static cluster_node *node_get_witch_connected(redisClusterContext *cc)
+static cluster_node *node_get_which_connected(redisClusterContext *cc)
 {
     dictIterator *di;
     dictEntry *de;
@@ -2505,7 +2505,7 @@ static char * cluster_config_get(redisClusterContext *cc,
         return NULL;
     }
     
-    node = node_get_witch_connected(cc);
+    node = node_get_which_connected(cc);
     if(node == NULL)
     {
         __redisClusterSetError(cc, 
@@ -2799,7 +2799,7 @@ retry:
     }
     else if(c->err)
     {
-        node = node_get_witch_connected(cc);
+        node = node_get_which_connected(cc);
         if(node == NULL)
         {
             __redisClusterSetError(cc, REDIS_ERR_OTHER, "no reachable node in cluster");
@@ -3764,7 +3764,7 @@ int redisClusterAppendCommandArgv(redisClusterContext *cc,
     return ret;
 }
 
-static int redisCLusterSendAll(redisClusterContext *cc)
+static int redisClusterSendAll(redisClusterContext *cc)
 {
     dictIterator *di;
     dictEntry *de;
@@ -3899,7 +3899,7 @@ error:
     return REDIS_ERR;
 }
 
-void redisCLusterReset(redisClusterContext *cc)
+void redisClusterReset(redisClusterContext *cc)
 {
     redisContext *c = NULL;
     int status;
@@ -3910,7 +3910,7 @@ void redisCLusterReset(redisClusterContext *cc)
         return;
     }
 
-    redisCLusterSendAll(cc);
+    redisClusterSendAll(cc);
     
     do{
         status = redisClusterGetReply(cc, &reply);
@@ -4222,7 +4222,7 @@ static void redisClusterAsyncCallback(redisAsyncContext *ac, void *r, void *priv
     if(reply == NULL)
     {
         //Note: 
-        //I can't decide witch is the best way to deal with connect 
+        //I can't decide which is the best way to deal with connect 
         //problem for hiredis cluster async api.
         //But now the way is : when enough null reply for a node,
         //we will update the route after the cluster node timeout.

--- a/hircluster.c
+++ b/hircluster.c
@@ -649,9 +649,7 @@ static void cluster_nodes_swap_ctx(dict *nodes_f, dict *nodes_t)
 static int
 cluster_slot_start_cmp(const void *t1, const void *t2)
 {
-    const cluster_slot **s1 = t1, **s2 = t2;
-
-    return (*s1)->start > (*s2)->start?1:-1;
+    return ((cluster_slot*)t1)->start > ((cluster_slot*)t2)->start ? 1 : -1;
 }
 
 static int

--- a/hircluster.h
+++ b/hircluster.h
@@ -118,7 +118,7 @@ int redisClustervAppendCommand(redisClusterContext *cc, const char *format, va_l
 int redisClusterAppendCommand(redisClusterContext *cc, const char *format, ...);
 int redisClusterAppendCommandArgv(redisClusterContext *cc, int argc, const char **argv, const size_t *argvlen);
 int redisClusterGetReply(redisClusterContext *cc, void **reply);
-void redisCLusterReset(redisClusterContext *cc);
+void redisClusterReset(redisClusterContext *cc);
 
 int cluster_update_route(redisClusterContext *cc);
 int test_cluster_update_route(redisClusterContext *cc);


### PR DESCRIPTION
May not have fully understood the reasoning for the capitalization in the interface, but in developing a binding for ruby into hiredis-vip if seemed like a consistent mechanism for capitalization in the methods would be beneficial

also updated a cast to get some gcc warnings to go away and not create the local references when only using them for comparison which can be done directly