### PR TITLE
Fix redisClusterAsyncDisconnect memory leak

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -4944,6 +4944,8 @@ void redisClusterAsyncDisconnect(redisClusterAsyncContext *acc) {
 
         node->acon = NULL;
     }
+
+    dictReleaseIterator(di);
 }
 
 void redisClusterAsyncFree(redisClusterAsyncContext *acc)


### PR DESCRIPTION
The redisClusterAsyncDisconnect function was not freeing the iterator that was obtained from dictGetIterator. 