### PR TITLE
fix a bug which cause mem leak when post multikey result

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3468,7 +3468,8 @@ static void *command_post_fragment(redisClusterContext *cc,
             NOT_REACHED();
         }
     }
-
+		listReleaseIterator(list_iter);
+		
     reply = hi_calloc(1,sizeof(*reply));
 
     if (reply == NULL)


### PR DESCRIPTION
Got this mem leak point, please check it.