### PR TITLE
Rohan broadcast support

### DIFF
--- a/command.c
+++ b/command.c
@@ -46,6 +46,7 @@ redis_arg0(struct cmd *r)
 
     case CMD_REQ_REDIS_DECR:
     case CMD_REQ_REDIS_GET:
+    case CMD_REQ_REDIS_KEYS:
     case CMD_REQ_REDIS_INCR:
     case CMD_REQ_REDIS_STRLEN:
 
@@ -485,6 +486,11 @@ redis_parse_cmd(struct cmd *r)
                 break;
 
             case 4:
+                if (str4icmp(m, 'k', 'e', 'y', 's')) {
+                    r->type = CMD_REQ_REDIS_KEYS;
+                    break;
+                }
+
                 if (str4icmp(m, 'p', 't', 't', 'l')) {
                     r->type = CMD_REQ_REDIS_PTTL;
                     break;

--- a/command.h
+++ b/command.h
@@ -126,7 +126,7 @@ typedef enum cmd_parse_result {
     ACTION( RSP_REDIS_BULK )                                                                        \
     ACTION( RSP_REDIS_MULTIBULK )                                                                   \
     ACTION( SENTINEL )                                                                              \
-
+    ACTION( REQ_REDIS_KEYS )
 
 #define DEFINE_ACTION(_name) CMD_##_name,
 typedef enum cmd_type {

--- a/hircluster.c
+++ b/hircluster.c
@@ -5073,3 +5073,18 @@ void redisClusterAsyncFree(redisClusterAsyncContext *acc)
     hi_free(acc);
 }
 
+void print_reply(redisReply *reply){
+    switch(reply->type){
+        case REDIS_REPLY_STRING:printf("REDIS_REPLY_STRING, Reply:%s\n",reply->str);break;
+        case REDIS_REPLY_ARRAY:printf("REDIS_REPLY_ARRAY with %d elements\n",reply->elements);
+            for(int i=0;i<(reply->elements);i++){
+                print_reply((reply->element)[i]);
+            }
+            break;
+        case REDIS_REPLY_INTEGER:printf("REDIS_REPLY_INTEGER, Reply:%lld\n",reply->integer);break; 
+        case REDIS_REPLY_NIL:printf("REDIS_REPLY_NIL\n");break;
+        case REDIS_REPLY_STATUS:printf("REDIS_REPLY_STATUS, Reply:%s\n",reply->str);break;
+        case REDIS_REPLY_ERROR:printf("REDIS_REPLY_ERROR, Reply:%s\n",reply->str);break;
+        default: printf("Unknown Reply Type");
+    }
+}

--- a/hircluster.h
+++ b/hircluster.h
@@ -142,6 +142,8 @@ int test_cluster_update_route(redisClusterContext *cc);
 struct dict *parse_cluster_nodes(redisClusterContext *cc, char *str, int str_len, int flags);
 struct dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply, int flags);
 
+void *redisClusterBroadcastCommand(redisClusterContext *cc, const char *format, ...);
+redisReply *redisCLusterCommandSendAll(redisClusterContext *cc,char *cmd,size_t len);
 
 /*############redis cluster async############*/
 

--- a/hircluster.h
+++ b/hircluster.h
@@ -144,7 +144,7 @@ struct dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply, int
 
 void *redisClusterBroadcastCommand(redisClusterContext *cc, const char *format, ...);
 redisReply *redisCLusterCommandSendAll(redisClusterContext *cc,char *cmd,size_t len);
-
+void print_reply(redisReply *reply);
 /*############redis cluster async############*/
 
 struct redisClusterAsyncContext;


### PR DESCRIPTION
Added redisClusterBroadcastCommand and redisClusterCommandSendAll functions.
Reply from all nodes is collectively given out. These functions are especially useful with 'keys <regex>' command and data is distributed across various nodes.